### PR TITLE
Adding CRUD Operations on Bulk Entity - Update Elevate Project

### DIFF
--- a/Elevate_QA_API.xml
+++ b/Elevate_QA_API.xml
@@ -44,6 +44,7 @@
             <class name="org.shikshalokam.backend.ep.TestElevateBulkEntityCRUDOperations">
                 <methods>
                     <include name="testValidEntityBulkCreate"/>
+                    <include name="testValidEntityBulkUpdate"/>
                 </methods>
             </class>
         </classes>

--- a/src/main/resources/bulk_entity_update_ElevateProject.csv
+++ b/src/main/resources/bulk_entity_update_ElevateProject.csv
@@ -1,0 +1,4 @@
+externalId,name,region,capital,_arrayFields,_existingKeyField,_SYSTEM_ID
+EntityId,EntityName,North east,Chandigarh,,externalId,SYSTEM_Id
+EntityId,EntityName,North east,Chandigarh,,externalId,SYSTEM_Id
+EntityId,EntityName,North east,Chandigarh,,externalId,SYSTEM_Id

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -17,5 +17,7 @@ updateUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/update/
 findUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/find
 deleteUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/delete/
 elevate.qa.bulkentity.create=entity-management/v1/entities/bulkCreate
+elevate.qa.bulkentity.update=entity-management/v1/entities/bulkUpdate
 elevate.qa.automation.entitytype.name=Automation_Entitytype
 elevate.qa.automation.entitytype.Id=671ada4002fe677644c86979
+elevate.qa.fetchentity.endpoint=entity-management/v1/entities/find

--- a/src/test/java/org/shikshalokam/backend/ep/TestElevateBulkEntityCRUDOperations.java
+++ b/src/test/java/org/shikshalokam/backend/ep/TestElevateBulkEntityCRUDOperations.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,7 +35,7 @@ public class TestElevateBulkEntityCRUDOperations extends ElevateProjectBaseTest 
     public void testValidEntityBulkCreate() {
         updateCsvWithName("src/main/resources/bulk_entity_valid_create_ElevateProject.csv", "target/classes/bulk_entity_valid_create_ElevateProject.csv");
         updateCsvWithEntityId("target/classes/bulk_entity_valid_create_ElevateProject.csv", "target/classes/bulk_entity_valid_create_ElevateProject.csv");
-        Response response = testUploadCsvFile("target/classes/bulk_entity_valid_create_ElevateProject.csv", "elevate.qa.bulkentity.create", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        Response response = testUploadCreateCsvFile("target/classes/bulk_entity_valid_create_ElevateProject.csv", "elevate.qa.bulkentity.create", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 200);
         logger.info("Validations related to valid CSV bulk upload entity file is verified");
     }
@@ -42,12 +43,22 @@ public class TestElevateBulkEntityCRUDOperations extends ElevateProjectBaseTest 
     //This test case has an issue hence we cannot use this TC until the fix is been provided by the devs
     @Test
     public void testInvalidEntityBulkCreate() {
-        Response response = testUploadCsvFile("src/main/resources/bulk_entity_invalid_create_ElevateProject.csv", "elevate.qa.bulkentity.create", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        Response response = testUploadCreateCsvFile("src/main/resources/bulk_entity_invalid_create_ElevateProject.csv", "elevate.qa.bulkentity.create", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 400);
         logger.info("Validations related to Invalid CSV bulk upload entity file is verified");
     }
 
-    private Response testUploadCsvFile(String path, String endpoint, String EntityType) {
+    @Test(dependsOnMethods = "testValidEntityBulkCreate")
+    public void testValidEntityBulkUpdate() {
+        updateCsvWithSystemID("src/main/resources/bulk_entity_update_ElevateProject.csv", "target/classes/bulk_entity_update_ElevateProject.csv");
+        updateCsvWithName("target/classes/bulk_entity_update_ElevateProject.csv", "target/classes/bulk_entity_update_ElevateProject.csv");
+        updateCsvWithEntityId("target/classes/bulk_entity_update_ElevateProject.csv", "target/classes/bulk_entity_update_ElevateProject.csv");
+        Response response = testUploadUpdateCsvFile("target/classes/bulk_entity_update_ElevateProject.csv", "elevate.qa.bulkentity.update");
+        Assert.assertEquals(response.getStatusCode(), 200, "Status code is not 200 " + response.getStatusCode());
+        Assert.assertTrue(response.asString().contains("SUCCESS"), "Does not contain SUCCESS");
+    }
+
+    private Response testUploadCreateCsvFile(String path, String endpoint, String EntityType) {
         // Path to the CSV file
         File csvFile = new File(path);
         if (!csvFile.exists()) {
@@ -59,6 +70,23 @@ public class TestElevateBulkEntityCRUDOperations extends ElevateProjectBaseTest 
                 .header("x-auth-token", X_AUTH_TOKEN)  // x-authenticated-token header
                 .header("Content-Type", "multipart/form-data")  // Content-Type for file upload
                 .queryParam("type", EntityType)
+                .post(PropertyLoader.PROP_LIST.getProperty(endpoint));
+        logger.info("Response Status Code: " + response.getStatusCode());
+        response.prettyPrint();
+        return response;
+    }
+
+    private Response testUploadUpdateCsvFile(String path, String endpoint) {
+        // Path to the CSV file
+        File csvFile = new File(path);
+        if (!csvFile.exists()) {
+            logger.error("CSV file does not exist: " + csvFile.getAbsolutePath());
+        }
+        // Send the POST request to upload the CSV file
+        Response response = given().multiPart("entities", csvFile)
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)  // Internal access token header
+                .header("x-auth-token", X_AUTH_TOKEN)  // x-authenticated-token header
+                .header("Content-Type", "multipart/form-data")  // Content-Type for file upload
                 .post(PropertyLoader.PROP_LIST.getProperty(endpoint));
         logger.info("Response Status Code: " + response.getStatusCode());
         response.prettyPrint();
@@ -95,6 +123,29 @@ public class TestElevateBulkEntityCRUDOperations extends ElevateProjectBaseTest 
             Files.write(Paths.get(targetPath), CSVcontent.getBytes());
             logger.info("Updated Content:\n" + CSVcontent);
         } catch (IOException e) {
+            logger.info(e + "Error!!!");
+        }
+    }
+
+    private void updateCsvWithSystemID(String sourcePath, String targetPath) {
+        try {
+            String CSVcontent = new String(Files.readAllBytes(Paths.get(sourcePath)));
+            HashMap<String, String> map = new HashMap<>();
+            List<String> entityId = new ArrayList<>();
+            for (String external_id : randomEntityId) {
+                String entity_Id = getSystemId(external_id);
+                map.put(external_id, entity_Id);
+                entityId.add(entity_Id);
+            }
+            System.out.println("keylist = " + entityId);
+            for (String EntityID : entityId) {
+                CSVcontent = CSVcontent.replaceFirst("SYSTEM_Id", EntityID.replaceAll("[\\[\\]]", ""));
+            }
+            Files.write(Paths.get(targetPath), CSVcontent.getBytes());
+            logger.info("Updated Content:\n\n" + CSVcontent);
+
+        } catch (
+                IOException e) {
             logger.info(e + "Error!!!");
         }
     }


### PR DESCRIPTION
1. Improvement instead of using HashMap I have used JSON Object for request body
2. Added methods to get entity details and extract the entity system ID in base class (NOTE- it will be used in single entity CRUD ops hence it is in the base class)
3. Added update bulk entity method for which a new method for uploading the update CSV file has been written because the other method for creation uses query parameter whereas the method for upload does not(NOTE:- added it has a method so that It can be used for negative flows too).
4. Added a method to put the systemID into the CSV file for update CSV related flows.