### PR TITLE
Adding CRUD Operations on Single entity

### DIFF
--- a/Elevate_QA_API.xml
+++ b/Elevate_QA_API.xml
@@ -53,7 +53,9 @@
                     <include name="testAddingValidEntity"/>
                     <include name="testAddingInvalidEntity"/>
                     <include name="testUpdatingEntity"/>
-
+                    <include name="testFetchValidEntityDetails"/>
+                    <include name="testMappingEntities"/>
+                    <include name="fetchEntityListBasedOnEntityId"/>
                 </methods>
             </class>
         </classes>

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -12,6 +12,9 @@ elevate.qa.bulkenitytype.create.endpoint=entity-management/v1/entityTypes/bulkCr
 elevate.qa.bulkenitytype.update.endpoint=entity-management/v1/entityTypes/bulkUpdate
 elevate.qa.entityType=block
 elevate.qa.entityTypeId=6673131ec05aa58f89ba12fa
+elevate.qa.entityName=Automation_Entity
+elevate.qa.entityID=67333246b1422706754bf953
+elevate.qa.entity.externalID=Automation_Entity123
 createUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/create
 updateUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/update/
 findUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/find
@@ -22,6 +25,7 @@ elevate.qa.automation.entitytype.name=Automation_Entitytype
 elevate.qa.automation.entitytype.Id=671ada4002fe677644c86979
 elevate.qa.fetchentity.endpoint=entity-management/v1/entities/find
 elevate.qa.entityadd.endpoint=entity-management/v1/entities/add
-elevate.qa.entityupdate.endpoint=entity-management/v1/entities/update/
+elevate.qa.fetchentity.list.endpoint=entity-management/v1/entities/list/
+elevate.qa.mapping.entity.endpoint=entity-management/v1/entities/mappingUpload
 
 

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -27,5 +27,6 @@ elevate.qa.fetchentity.endpoint=entity-management/v1/entities/find
 elevate.qa.entityadd.endpoint=entity-management/v1/entities/add
 elevate.qa.fetchentity.list.endpoint=entity-management/v1/entities/list/
 elevate.qa.mapping.entity.endpoint=entity-management/v1/entities/mappingUpload
+elevate.qa.entityupdate.endpoint=entity-management/v1/entities/update/
 
 

--- a/src/main/resources/entities_mapping_ElevateProject.csv
+++ b/src/main/resources/entities_mapping_ElevateProject.csv
@@ -1,0 +1,2 @@
+parentEntiyId,childEntityId
+67333246b1422706754bf953,childEntityID

--- a/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
+++ b/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
@@ -10,14 +10,20 @@ import org.shikshalokam.backend.PropertyLoader;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
 import static io.restassured.RestAssured.given;
 
 public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     private Logger logger = LogManager.getLogger(TestElevateEntityCRUDOperations.class);
     private String randomEntityName = RandomStringUtils.randomAlphabetic(10);
     private String randomExternalId = RandomStringUtils.randomAlphabetic(10);
+
 
     @BeforeMethod
     public void setUp() {
@@ -33,21 +39,57 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
         Assert.assertEquals(response.jsonPath().getString("message"), "ENTITY_ADDED");
         logger.info("Validation of entity addition is successful.");
     }
+
     @Test(description = "Adding a invalid entity")
     public void testAddingInvalidEntity() {
         Response response = addEntity("", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), "", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 400);
         Assert.assertTrue(response.asString().contains("The name field cannot be empty."));
-        logger.info("Validation of invalidentity addition is successful.");
+        logger.info("Validation of invalid entity addition is successful.");
     }
 
-    @Test(description = "Updating the entity with a random name",dependsOnMethods ="testAddingValidEntity" )
-    public void testUpdatingEntity() {
+    @Test(description = "Updating the entity with a random name", dependsOnMethods = "testAddingValidEntity")
+    public void testUpdateValidEntity() {
         getSystemId(randomExternalId);
-        Response response = updateEntity( entity_Id,randomEntityName +"123",randomExternalId + "dfdf7gd");
+        Response response = updateEntity(entity_Id, randomEntityName + "123", randomExternalId + "dfdf7gd");
         Assert.assertEquals(response.getStatusCode(), 200);
-        Assert.assertTrue(response.asString().contains(randomEntityName),"entity not found");
+        Assert.assertTrue(response.asString().contains(randomEntityName), "entity not found");
         logger.info("Entity updated successfully to: " + randomEntityName);
+    }
+
+    @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
+    public void testFetchValidEntityDetails() {
+        Response response = fetchEntitydetails(randomExternalId);
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.jsonPath().getString("message").contains("ASSETS_FETCHED_SUCCESSFULLY"));
+        logger.info("Validations related to fetching the Valid single entity details is verified");
+    }
+
+    //This TC cannot be verified at the moment because there is an entity which is created with no name
+    @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
+    public void testInvalidFetchEntityDetails() {
+        Response response = fetchEntitydetails("");
+        Assert.assertEquals(response.getStatusCode(), 400);
+        Assert.assertTrue(response.jsonPath().getString("message").contains("ENTITY_NOT_FOUND"));
+        logger.info("Validations related to fetching the Invalid single entity details is verified");
+    }
+
+    @Test(description = "Mapping the entities to parent entity using CSV upload")
+    public void testMappingEntities() {
+        addEntity(randomEntityName, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), randomExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        testUploadEntitiesMappingCsvFile("src/main/resources/entities_mapping_ElevateProject.csv", "target/classes/entities_mapping_ElevateProject.csv");
+        Response response = uploadMappingCSV("target/classes/entities_mapping_ElevateProject.csv", PropertyLoader.PROP_LIST.getProperty("elevate.qa.mapping.entity.endpoint"));
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains("ENTITY_INFORMATION_UPDATE"));
+        logger.info("Validations related to Mapping entities are verified");
+    }
+
+    @Test(description = "", dependsOnMethods = "testMappingEntities")
+    public void fetchEntityListBasedOnEntityId() {
+        getSystemId(PropertyLoader.PROP_LIST.getProperty("elevate.qa.entity.externalID"));
+        Response response = fetchEntityListBasedOnEntityId(entity_Id, "1", "100", "Automation_Entitytype");
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains(randomEntityName), "Entity not found in the list");
     }
 
     // Method to add the entity
@@ -68,9 +110,8 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     }
 
     // Method to update an entity by its ID
-    private Response updateEntity(String entityid ,String updatedEntityName, String updatedExternalId) {
+    private Response updateEntity(String entityid, String updatedEntityName, String updatedExternalId) {
         JSONObject requestBody = new JSONObject();
-
         requestBody.put("metaInformation.externalId", updatedExternalId);
         requestBody.put("metaInformation.name", updatedEntityName);
         requestBody.put("childHierarchyPath", new JSONArray());
@@ -81,14 +122,63 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
                 .header("x-auth-token", X_AUTH_TOKEN)
                 .header("Content-Type", "application/json")
                 .body(requestBody)
-                .pathParam("_id",entityid )
+                .pathParam("_id", entityid)
                 .post(PropertyLoader.PROP_LIST.getProperty("elevate.qa.entityupdate.endpoint") + "{_id}");
         response.prettyPrint();
         return response;
     }
+
+    private Response fetchEntityListBasedOnEntityId(String entityid, String page, String limit, String entityType) {
+        Response response = given()
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)
+                .header("x-auth-token", X_AUTH_TOKEN)
+                .header("Content-Type", "application/json")
+                .pathParam("_id", entityid)
+                .queryParam("page", page)
+                .queryParam("limit", limit)
+                .queryParam("type", entityType)
+                .get(PropertyLoader.PROP_LIST.getProperty("elevate.qa.fetchentity.list.endpoint") + "{_id}");
+        response.prettyPrint();
+        return response;
+    }
+
+    private void testUploadEntitiesMappingCsvFile(String sourcePath, String targetPath) {
+        // Path to the CSV file
+
+        try {
+            String CSVcontent = new String(Files.readAllBytes(Paths.get(sourcePath)));
+            List<String> childEntityID;
+            childEntityID = Collections.singletonList(getSystemId(randomExternalId));
+            logger.info("Original Content:\n" + CSVcontent);
+            for (String childEntity : childEntityID) {
+                CSVcontent = CSVcontent.replaceFirst("childEntityID", childEntity);
+                Files.write(Paths.get(targetPath), CSVcontent.getBytes());
+                logger.info("Updated Content:\n" + CSVcontent);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Response uploadMappingCSV(String targetPath, String endpoint) {
+        File csvFile = new File(targetPath);
+        logger.info(csvFile + "**************************8");
+        if (!csvFile.exists()) {
+            logger.error("CSV file does not exist: " + csvFile.getAbsolutePath());
+        }
+        // Send the POST request to upload the CSV file
+        Response response = given()
+                .multiPart("entityMap", csvFile)
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)  // Internal access token header
+                .header("x-auth-token", X_AUTH_TOKEN)  // x-authenticated-token header
+                .header("Content-Type", "multipart/form-data")
+                .post(endpoint);
+        logger.info("Response Status Code: " + response.getStatusCode());
+        response.prettyPrint();
+        return response;
+    }
 }
-
-
 
 
 


### PR DESCRIPTION
Adding CRUD Operations on Single entity
1) TC for fetching an entity detail (both negative and positive)
2) TC for uploading mapping of entities.
3) TC for fetching entity list based on entity ID

and all the methods associated with the test cases