### PR TITLE
CRUD ops on single Entity - Elevate Project

### DIFF
--- a/Elevate_QA_API.xml
+++ b/Elevate_QA_API.xml
@@ -53,7 +53,9 @@
                     <include name="testAddingValidEntity"/>
                     <include name="testAddingInvalidEntity"/>
                     <include name="testUpdatingEntity"/>
-
+                    <include name="testFetchValidEntityDetails"/>
+                    <include name="testMappingEntities"/>
+                    <include name="fetchEntityListBasedOnEntityId"/>
                 </methods>
             </class>
         </classes>

--- a/Elevate_QA_API.xml
+++ b/Elevate_QA_API.xml
@@ -53,6 +53,8 @@
                     <include name="testAddingValidEntity"/>
                     <include name="testAddingInvalidEntity"/>
                     <include name="testUpdatingEntity"/>
+                    <include name="testUpdateEntityToDifferentEntityType"/>
+                    <include name="testUpdateInvalidEntity"/>
                     <include name="testFetchValidEntityDetails"/>
                     <include name="testMappingEntities"/>
                     <include name="fetchEntityListBasedOnEntityId"/>

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -12,6 +12,9 @@ elevate.qa.bulkenitytype.create.endpoint=entity-management/v1/entityTypes/bulkCr
 elevate.qa.bulkenitytype.update.endpoint=entity-management/v1/entityTypes/bulkUpdate
 elevate.qa.entityType=block
 elevate.qa.entityTypeId=6673131ec05aa58f89ba12fa
+elevate.qa.entityName=Automation_Entity
+elevate.qa.entityID=67333246b1422706754bf953
+elevate.qa.entity.externalID=Automation_Entity123
 createUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/create
 updateUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/update/
 findUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/find
@@ -22,6 +25,7 @@ elevate.qa.automation.entitytype.name=Automation_Entitytype
 elevate.qa.automation.entitytype.Id=671ada4002fe677644c86979
 elevate.qa.fetchentity.endpoint=entity-management/v1/entities/find
 elevate.qa.entityadd.endpoint=entity-management/v1/entities/add
-elevate.qa.entityupdate.endpoint=entity-management/v1/entities/update/
+elevate.qa.fetchentity.list.endpoint=entity-management/v1/entities/list/
+elevate.qa.mapping.entity.endpoint=entity-management/v1/entities/mappingUpload
 
 

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -14,18 +14,21 @@ elevate.qa.entityType=block
 elevate.qa.entityTypeId=6673131ec05aa58f89ba12fa
 elevate.qa.entityName=Automation_Entity
 elevate.qa.entityID=67333246b1422706754bf953
-elevate.qa.entity.externalID=Automation_Entity123
-createUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/create
-updateUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/update/
-findUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/find
-deleteUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/delete/
+createUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/create
+updateUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/update/
+findUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/find
+deleteUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/delete/
 elevate.qa.bulkentity.create=entity-management/v1/entities/bulkCreate
 elevate.qa.bulkentity.update=entity-management/v1/entities/bulkUpdate
 elevate.qa.automation.entitytype.name=Automation_Entitytype
 elevate.qa.automation.entitytype.Id=671ada4002fe677644c86979
 elevate.qa.fetchentity.endpoint=entity-management/v1/entities/find
 elevate.qa.entityadd.endpoint=entity-management/v1/entities/add
+elevate.qa.entityupdate.endpoint=entity-management/v1/entities/update/
 elevate.qa.fetchentity.list.endpoint=entity-management/v1/entities/list/
 elevate.qa.mapping.entity.endpoint=entity-management/v1/entities/mappingUpload
+elevate.qa.update.entitytype.name=school
+elevate.qa.parent.entity.externalId=Automation_ExternalId123
+
 
 

--- a/src/main/resources/entities_mapping_ElevateProject.csv
+++ b/src/main/resources/entities_mapping_ElevateProject.csv
@@ -1,2 +1,2 @@
 parentEntiyId,childEntityId
-67333246b1422706754bf953,childEntityID
+parentEntity_Id,childEntity_ID

--- a/src/main/resources/entities_mapping_ElevateProject.csv
+++ b/src/main/resources/entities_mapping_ElevateProject.csv
@@ -1,0 +1,2 @@
+parentEntiyId,childEntityId
+67333246b1422706754bf953,childEntityID

--- a/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
+++ b/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
@@ -23,6 +23,8 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     private Logger logger = LogManager.getLogger(TestElevateEntityCRUDOperations.class);
     private String randomEntityName = RandomStringUtils.randomAlphabetic(10);
     private String randomExternalId = RandomStringUtils.randomAlphabetic(10);
+    private String updatedEntityName = RandomStringUtils.randomAlphabetic(10);
+    private String updatedEntityExternalId = RandomStringUtils.randomAlphabetic(10);
 
 
     @BeforeMethod
@@ -34,6 +36,7 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
 
     @Test(description = "Adding a valid entity")
     public void testAddingValidEntity() {
+        logger.info("**************************" + randomExternalId);
         Response response = addEntity(randomEntityName, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), randomExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 200);
         Assert.assertEquals(response.jsonPath().getString("message"), "ENTITY_ADDED");
@@ -50,11 +53,44 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
 
     @Test(description = "Updating the entity with a random name", dependsOnMethods = "testAddingValidEntity")
     public void testUpdateValidEntity() {
+        logger.info("**************************" + randomExternalId);
         getSystemId(randomExternalId);
-        Response response = updateEntity(entity_Id, randomEntityName + "123", randomExternalId + "dfdf7gd");
+        Response response = updateEntity(entity_Id, updatedEntityName, updatedEntityExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 200);
-        Assert.assertTrue(response.asString().contains(randomEntityName), "entity not found");
-        logger.info("Entity updated successfully to: " + randomEntityName);
+        Assert.assertTrue(response.asString().contains(updatedEntityName), "entity not found");
+        logger.info("Validation related to updating an single entity is verified");
+    }
+
+    @Test(description = "Updating the entity to a different entity type", dependsOnMethods = "testAddingValidEntity")
+    public void testUpdateEntityToDifferentEntityType() {
+        getSystemId(randomExternalId);
+        Response response = updateEntity(entity_Id, updatedEntityName, updatedEntityExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.update.entitytype.name"));
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains(updatedEntityName), "entity not found");
+        // Reverting the entity back to it's original entity type
+        updateEntity(entity_Id, updatedEntityName, updatedEntityExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        logger.info("Validations related to updating an entity to a different entity type is verified");
+    }
+
+    @Test(description = "Updating an Entity without passing the _Id as a parameter")
+    public void testUpdateInvalidEntity() {
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("entityType", "Automation_Entitytype");
+        requestBody.put("metaInformation.externalId", "");
+        requestBody.put("metaInformation.name", "");
+        requestBody.put("childHierarchyPath", new JSONArray());
+        requestBody.put("createdBy", "user123");
+        requestBody.put("updatedBy", "user123");
+        Response response = given()
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)
+                .header("x-auth-token", X_AUTH_TOKEN)
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .post("entity-management/v1/entities/update");
+        response.prettyPrint();
+        Assert.assertEquals(response.getStatusCode(), 400);
+        Assert.assertTrue(response.asString().contains("required _id"));
+        logger.info("Validation related to Invalid Updating of entity is verified");
     }
 
     @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
@@ -77,19 +113,21 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     @Test(description = "Mapping the entities to parent entity using CSV upload")
     public void testMappingEntities() {
         addEntity(randomEntityName, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), randomExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
-        testUploadEntitiesMappingCsvFile("src/main/resources/entities_mapping_ElevateProject.csv", "target/classes/entities_mapping_ElevateProject.csv");
+        updateCSVWithChildAndParentEntityNames("src/main/resources/entities_mapping_ElevateProject.csv", "target/classes/entities_mapping_ElevateProject.csv", PropertyLoader.PROP_LIST.getProperty("elevate.qa.parent.entity.externalId"), randomExternalId);
         Response response = uploadMappingCSV("target/classes/entities_mapping_ElevateProject.csv", PropertyLoader.PROP_LIST.getProperty("elevate.qa.mapping.entity.endpoint"));
         Assert.assertEquals(response.getStatusCode(), 200);
         Assert.assertTrue(response.asString().contains("ENTITY_INFORMATION_UPDATE"));
         logger.info("Validations related to Mapping entities are verified");
     }
 
-    @Test(description = "", dependsOnMethods = "testMappingEntities")
+    @Test(description = "Fetching the list of entities by using the entity Id", dependsOnMethods = "testMappingEntities")
     public void fetchEntityListBasedOnEntityId() {
-        getSystemId(PropertyLoader.PROP_LIST.getProperty("elevate.qa.entity.externalID"));
+        getSystemId(PropertyLoader.PROP_LIST.getProperty("elevate.qa.parent.entity.externalId"));
         Response response = fetchEntityListBasedOnEntityId(entity_Id, "1", "100", "Automation_Entitytype");
         Assert.assertEquals(response.getStatusCode(), 200);
         Assert.assertTrue(response.asString().contains(randomEntityName), "Entity not found in the list");
+        logger.info("Entity count = " + response.jsonPath().getString("count"));
+        logger.info("Validations related to fetching entity list based on entity Id is verified");
     }
 
     // Method to add the entity
@@ -110,8 +148,9 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     }
 
     // Method to update an entity by its ID
-    private Response updateEntity(String entityid, String updatedEntityName, String updatedExternalId) {
+    private Response updateEntity(String entityid, String updatedEntityName, String updatedExternalId, String updatedEntityTypeName) {
         JSONObject requestBody = new JSONObject();
+        requestBody.put("entityType", updatedEntityTypeName);
         requestBody.put("metaInformation.externalId", updatedExternalId);
         requestBody.put("metaInformation.name", updatedEntityName);
         requestBody.put("childHierarchyPath", new JSONArray());
@@ -128,6 +167,7 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
         return response;
     }
 
+    // Method to fetch Entity List based on entity Id
     private Response fetchEntityListBasedOnEntityId(String entityid, String page, String limit, String entityType) {
         Response response = given()
                 .header("internal-access-token", INTERNAL_ACCESS_TOKEN)
@@ -142,18 +182,27 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
         return response;
     }
 
-    private void testUploadEntitiesMappingCsvFile(String sourcePath, String targetPath) {
-        // Path to the CSV file
-
+    // Method to fill the mapping CSV with child entity ID's
+    private void updateCSVWithChildAndParentEntityNames(String sourcePath, String targetPath, String parentEntityID, String ChildEntityId) {
         try {
             String CSVcontent = new String(Files.readAllBytes(Paths.get(sourcePath)));
-            List<String> childEntityID;
-            childEntityID = Collections.singletonList(getSystemId(randomExternalId));
             logger.info("Original Content:\n" + CSVcontent);
-            for (String childEntity : childEntityID) {
-                CSVcontent = CSVcontent.replaceFirst("childEntityID", childEntity);
+            List<String> parentEntityId;
+            parentEntityId = Collections.singletonList(getSystemId(parentEntityID));
+            for (String parentEntity_Id : parentEntityId) {
+                CSVcontent = CSVcontent.replaceFirst("parentEntity_Id", parentEntity_Id);
                 Files.write(Paths.get(targetPath), CSVcontent.getBytes());
                 logger.info("Updated Content:\n" + CSVcontent);
+            }
+
+            String CSVcontentChild = new String(Files.readAllBytes(Paths.get(targetPath)));
+            logger.info("Original Content:\n" + CSVcontentChild);
+            List<String> childEntityID;
+            childEntityID = Collections.singletonList(getSystemId(ChildEntityId));
+            for (String childEntity : childEntityID) {
+                CSVcontentChild = CSVcontentChild.replaceFirst("childEntity_ID", childEntity);
+                Files.write(Paths.get(targetPath), CSVcontentChild.getBytes());
+                logger.info("Updated Content:\n" + CSVcontentChild);
             }
 
         } catch (IOException e) {
@@ -161,13 +210,12 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
         }
     }
 
+    //Method to Map the child entity to parent entity using an CSV
     private Response uploadMappingCSV(String targetPath, String endpoint) {
         File csvFile = new File(targetPath);
-        logger.info(csvFile + "**************************8");
         if (!csvFile.exists()) {
             logger.error("CSV file does not exist: " + csvFile.getAbsolutePath());
         }
-        // Send the POST request to upload the CSV file
         Response response = given()
                 .multiPart("entityMap", csvFile)
                 .header("internal-access-token", INTERNAL_ACCESS_TOKEN)  // Internal access token header

--- a/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
+++ b/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
@@ -10,14 +10,20 @@ import org.shikshalokam.backend.PropertyLoader;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
 import static io.restassured.RestAssured.given;
 
 public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     private Logger logger = LogManager.getLogger(TestElevateEntityCRUDOperations.class);
     private String randomEntityName = RandomStringUtils.randomAlphabetic(10);
     private String randomExternalId = RandomStringUtils.randomAlphabetic(10);
+
 
     @BeforeMethod
     public void setUp() {
@@ -33,21 +39,57 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
         Assert.assertEquals(response.jsonPath().getString("message"), "ENTITY_ADDED");
         logger.info("Validation of entity addition is successful.");
     }
+
     @Test(description = "Adding a invalid entity")
     public void testAddingInvalidEntity() {
         Response response = addEntity("", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), "", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 400);
         Assert.assertTrue(response.asString().contains("The name field cannot be empty."));
-        logger.info("Validation of invalidentity addition is successful.");
+        logger.info("Validation of invalid entity addition is successful.");
     }
 
-    @Test(description = "Updating the entity with a random name",dependsOnMethods ="testAddingValidEntity" )
-    public void testUpdatingEntity() {
+    @Test(description = "Updating the entity with a random name", dependsOnMethods = "testAddingValidEntity")
+    public void testUpdateValidEntity() {
         getSystemId(randomExternalId);
-        Response response = updateEntity( entity_Id,randomEntityName +"123",randomExternalId + "dfdf7gd");
+        Response response = updateEntity(entity_Id, randomEntityName + "123", randomExternalId + "dfdf7gd");
         Assert.assertEquals(response.getStatusCode(), 200);
-        Assert.assertTrue(response.asString().contains(randomEntityName),"entity not found");
+        Assert.assertTrue(response.asString().contains(randomEntityName), "entity not found");
         logger.info("Entity updated successfully to: " + randomEntityName);
+    }
+
+    @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
+    public void testFetchValidEntityDetails() {
+        Response response = fetchEntitydetails(randomExternalId);
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.jsonPath().getString("message").contains("ASSETS_FETCHED_SUCCESSFULLY"));
+        logger.info("Validations related to fetching the Valid single entity details is verified");
+    }
+
+    //This TC cannot be verified at the moment because there is an entity which is created with no name
+    @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
+    public void testInvalidFetchEntityDetails() {
+        Response response = fetchEntitydetails("");
+        Assert.assertEquals(response.getStatusCode(), 400);
+        Assert.assertTrue(response.jsonPath().getString("message").contains("ENTITY_NOT_FOUND"));
+        logger.info("Validations related to fetching the Invalid single entity details is verified");
+    }
+
+    @Test(description = "Mapping the entities to parent entity using CSV upload")
+    public void testMappingEntities() {
+        addEntity(randomEntityName, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), randomExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        testUploadEntitiesMappingCsvFile("src/main/resources/entities_mapping_ElevateProject.csv", "target/classes/entities_mapping_ElevateProject.csv");
+        Response response = uploadMappingCSV("target/classes/entities_mapping_ElevateProject.csv", PropertyLoader.PROP_LIST.getProperty("elevate.qa.mapping.entity.endpoint"));
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains("ENTITY_INFORMATION_UPDATE"));
+        logger.info("Validations related to Mapping entities are verified");
+    }
+
+    @Test(description = "", dependsOnMethods = "testMappingEntities")
+    public void fetchEntityListBasedOnEntityId() {
+        getSystemId(PropertyLoader.PROP_LIST.getProperty("elevate.qa.entity.externalID"));
+        Response response = fetchEntityListBasedOnEntityId(entity_Id, "1", "100", "Automation_Entitytype");
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains(randomEntityName), "Entity not found in the list");
     }
 
     // Method to add the entity
@@ -68,9 +110,8 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     }
 
     // Method to update an entity by its ID
-    private Response updateEntity(String entityid ,String updatedEntityName, String updatedExternalId) {
+    private Response updateEntity(String entityid, String updatedEntityName, String updatedExternalId) {
         JSONObject requestBody = new JSONObject();
-
         requestBody.put("metaInformation.externalId", updatedExternalId);
         requestBody.put("metaInformation.name", updatedEntityName);
         requestBody.put("childHierarchyPath", new JSONArray());
@@ -81,14 +122,63 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
                 .header("x-auth-token", X_AUTH_TOKEN)
                 .header("Content-Type", "application/json")
                 .body(requestBody)
-                .pathParam("_id",entityid )
+                .pathParam("_id", entityid)
                 .post(PropertyLoader.PROP_LIST.getProperty("elevate.qa.entityupdate.endpoint") + "{_id}");
         response.prettyPrint();
         return response;
     }
+
+    private Response fetchEntityListBasedOnEntityId(String entityid, String page, String limit, String entityType) {
+        Response response = given()
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)
+                .header("x-auth-token", X_AUTH_TOKEN)
+                .header("Content-Type", "application/json")
+                .pathParam("_id", entityid)
+                .queryParam("page", page)
+                .queryParam("limit", limit)
+                .queryParam("type", entityType)
+                .get(PropertyLoader.PROP_LIST.getProperty("elevate.qa.fetchentity.list.endpoint") + "{_id}");
+        response.prettyPrint();
+        return response;
+    }
+
+    private void testUploadEntitiesMappingCsvFile(String sourcePath, String targetPath) {
+        // Path to the CSV file
+
+        try {
+            String CSVcontent = new String(Files.readAllBytes(Paths.get(sourcePath)));
+            List<String> childEntityID;
+            childEntityID = Collections.singletonList(getSystemId(randomExternalId));
+            logger.info("Original Content:\n" + CSVcontent);
+            for (String childEntity : childEntityID) {
+                CSVcontent = CSVcontent.replaceFirst("childEntityID", childEntity);
+                Files.write(Paths.get(targetPath), CSVcontent.getBytes());
+                logger.info("Updated Content:\n" + CSVcontent);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Response uploadMappingCSV(String targetPath, String endpoint) {
+        File csvFile = new File(targetPath);
+        logger.info(csvFile + "**************************8");
+        if (!csvFile.exists()) {
+            logger.error("CSV file does not exist: " + csvFile.getAbsolutePath());
+        }
+        // Send the POST request to upload the CSV file
+        Response response = given()
+                .multiPart("entityMap", csvFile)
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)  // Internal access token header
+                .header("x-auth-token", X_AUTH_TOKEN)  // x-authenticated-token header
+                .header("Content-Type", "multipart/form-data")
+                .post(endpoint);
+        logger.info("Response Status Code: " + response.getStatusCode());
+        response.prettyPrint();
+        return response;
+    }
 }
-
-
 
 
 


### PR DESCRIPTION
Adding CRUD Operations on Single entity
Added Tc's for
<include name="testUpdateEntityToDifferentEntityType"/>
<include name="testUpdateInvalidEntity"/>
<include name="testFetchValidEntityDetails"/>
<include name="testMappingEntities"/>
<include name="fetchEntityListBasedOnEntityId"/>

 2.  Added enhancement to the request body of 
<include name="testUpdatingEntity"/>

3. Added methods for 
a) fetchEntityListBasedOnEntityId
b) updateCSVWithChildAndParentEntityNames
c) uploadMappingCSV

And also enhanced the logger statements of the previous TC's for better readability and understanding