### PR TITLE
Adding TC's for Single Entity CRUD Operations

### DIFF
--- a/Elevate_QA_API.xml
+++ b/Elevate_QA_API.xml
@@ -1,12 +1,9 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="SanitySuiteEP">
     <listeners>
         <listener class-name="org.shikshalokam.Listerners.SLCustomListener"/>
     </listeners>
-
     <test name="Test">
         <classes>
-
             <class name="org.shikshalokam.backend.ep.TestElevateLogin">
                 <methods>
                     <include name="testLoginWithValidCredentials"/>
@@ -14,7 +11,6 @@
                     <include name="testLoginWithEmptyFields"/>
                 </methods>
             </class>
-
             <class name="org.shikshalokam.backend.ep.TestElevateEntityTypeCRUDOperations">
                 <methods>
                     <include name="testCreatingSingleEntityType"/>
@@ -30,7 +26,6 @@
                     <include name="testBulkUpdateEntityTypeWithValidCsv"/>
                 </methods>
             </class>
-
             <class name="org.shikshalokam.backend.ep.TestCRUDUserRoleExtensionOperations">
                 <methods>
                     <include name="testCreateValidUserRoleExtension"/>
@@ -40,23 +35,24 @@
                     <include name="testDeleteUserRoleExtension"/>
                 </methods>
             </class>
-
             <class name="org.shikshalokam.backend.ep.TestElevateBulkEntityCRUDOperations">
                 <methods>
                     <include name="testValidEntityBulkCreate"/>
                     <include name="testValidEntityBulkUpdate"/>
                 </methods>
-
             </class>
             <class name="org.shikshalokam.backend.ep.TestElevateEntityCRUDOperations">
                 <methods>
                     <include name="testAddingValidEntity"/>
                     <include name="testAddingInvalidEntity"/>
                     <include name="testUpdatingEntity"/>
-
+                    <include name="testUpdateEntityToDifferentEntityType"/>
+                    <include name="testUpdateInvalidEntity"/>
+                    <include name="testFetchValidEntityDetails"/>
+                    <include name="testMappingEntities"/>
+                    <include name="fetchEntityListBasedOnEntityId"/>
                 </methods>
             </class>
         </classes>
     </test>
 </suite>
-

--- a/Elevate_QA_API.xml
+++ b/Elevate_QA_API.xml
@@ -35,6 +35,7 @@
                     <include name="testDeleteUserRoleExtension"/>
                 </methods>
             </class>
+
             <class name="org.shikshalokam.backend.ep.TestElevateBulkEntityCRUDOperations">
                 <methods>
                     <include name="testValidEntityBulkCreate"/>

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -29,6 +29,3 @@ elevate.qa.fetchentity.list.endpoint=entity-management/v1/entities/list/
 elevate.qa.mapping.entity.endpoint=entity-management/v1/entities/mappingUpload
 elevate.qa.update.entitytype.name=school
 elevate.qa.parent.entity.externalId=Automation_ExternalId123
-
-
-

--- a/src/main/resources/config/Automation_ElevateAPI_QA.properties
+++ b/src/main/resources/config/Automation_ElevateAPI_QA.properties
@@ -1,4 +1,3 @@
-environment=QA
 # Elevate project details
 elevate.qa.api.base.url=https://project-qa.elevate-apis.shikshalokam.org/
 elevate.login.endpoint=user/v1/account/login
@@ -13,10 +12,12 @@ elevate.qa.bulkenitytype.create.endpoint=entity-management/v1/entityTypes/bulkCr
 elevate.qa.bulkenitytype.update.endpoint=entity-management/v1/entityTypes/bulkUpdate
 elevate.qa.entityType=block
 elevate.qa.entityTypeId=6673131ec05aa58f89ba12fa
-createUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/create
-updateUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/update/
-findUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/find
-deleteUserRoleExtensionEndpoint = entity-management/v1/userRoleExtension/delete/
+elevate.qa.entityName=Automation_Entity
+elevate.qa.entityID=67333246b1422706754bf953
+createUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/create
+updateUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/update/
+findUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/find
+deleteUserRoleExtensionEndpoint=entity-management/v1/userRoleExtension/delete/
 elevate.qa.bulkentity.create=entity-management/v1/entities/bulkCreate
 elevate.qa.bulkentity.update=entity-management/v1/entities/bulkUpdate
 elevate.qa.automation.entitytype.name=Automation_Entitytype
@@ -24,5 +25,10 @@ elevate.qa.automation.entitytype.Id=671ada4002fe677644c86979
 elevate.qa.fetchentity.endpoint=entity-management/v1/entities/find
 elevate.qa.entityadd.endpoint=entity-management/v1/entities/add
 elevate.qa.entityupdate.endpoint=entity-management/v1/entities/update/
+elevate.qa.fetchentity.list.endpoint=entity-management/v1/entities/list/
+elevate.qa.mapping.entity.endpoint=entity-management/v1/entities/mappingUpload
+elevate.qa.update.entitytype.name=school
+elevate.qa.parent.entity.externalId=Automation_ExternalId123
+
 
 

--- a/src/main/resources/entities_mapping_ElevateProject.csv
+++ b/src/main/resources/entities_mapping_ElevateProject.csv
@@ -1,0 +1,2 @@
+parentEntiyId,childEntityId
+parentEntity_Id,childEntity_ID

--- a/src/main/resources/entities_mapping_ElevateProject.csv
+++ b/src/main/resources/entities_mapping_ElevateProject.csv
@@ -1,2 +1,4 @@
 parentEntiyId,childEntityId
-parentEntity_Id,childEntity_ID
+parentEntity_Id,childEntity_ID_1
+parentEntity_Id,childEntity_ID_2
+parentEntity_Id,childEntity_ID_3

--- a/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
+++ b/src/test/java/org/shikshalokam/backend/ep/TestElevateEntityCRUDOperations.java
@@ -10,14 +10,22 @@ import org.shikshalokam.backend.PropertyLoader;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
 import static io.restassured.RestAssured.given;
 
 public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     private Logger logger = LogManager.getLogger(TestElevateEntityCRUDOperations.class);
     private String randomEntityName = RandomStringUtils.randomAlphabetic(10);
     private String randomExternalId = RandomStringUtils.randomAlphabetic(10);
+    private String updatedEntityName = RandomStringUtils.randomAlphabetic(10);
+    private String updatedEntityExternalId = RandomStringUtils.randomAlphabetic(10);
+
 
     @BeforeMethod
     public void setUp() {
@@ -28,26 +36,98 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
 
     @Test(description = "Adding a valid entity")
     public void testAddingValidEntity() {
+        logger.info("**************************" + randomExternalId);
         Response response = addEntity(randomEntityName, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), randomExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 200);
         Assert.assertEquals(response.jsonPath().getString("message"), "ENTITY_ADDED");
         logger.info("Validation of entity addition is successful.");
     }
+
     @Test(description = "Adding a invalid entity")
     public void testAddingInvalidEntity() {
         Response response = addEntity("", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), "", PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 400);
         Assert.assertTrue(response.asString().contains("The name field cannot be empty."));
-        logger.info("Validation of invalidentity addition is successful.");
+        logger.info("Validation of invalid entity addition is successful.");
     }
 
-    @Test(description = "Updating the entity with a random name",dependsOnMethods ="testAddingValidEntity" )
-    public void testUpdatingEntity() {
+    @Test(description = "Updating the entity with a random name", dependsOnMethods = "testAddingValidEntity")
+    public void testUpdateValidEntity() {
+        logger.info("**************************" + randomExternalId);
         getSystemId(randomExternalId);
-        Response response = updateEntity( entity_Id,randomEntityName +"123",randomExternalId + "dfdf7gd");
+        Response response = updateEntity(entity_Id, updatedEntityName, updatedEntityExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
         Assert.assertEquals(response.getStatusCode(), 200);
-        Assert.assertTrue(response.asString().contains(randomEntityName),"entity not found");
-        logger.info("Entity updated successfully to: " + randomEntityName);
+        Assert.assertTrue(response.asString().contains(updatedEntityName), "entity not found");
+        logger.info("Validation related to updating an single entity is verified");
+    }
+
+    @Test(description = "Updating the entity to a different entity type", dependsOnMethods = "testAddingValidEntity")
+    public void testUpdateEntityToDifferentEntityType() {
+        getSystemId(randomExternalId);
+        Response response = updateEntity(entity_Id, updatedEntityName, updatedEntityExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.update.entitytype.name"));
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains(updatedEntityName), "entity not found");
+        // Reverting the entity back to it's original entity type
+        updateEntity(entity_Id, updatedEntityName, updatedEntityExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        logger.info("Validations related to updating an entity to a different entity type is verified");
+    }
+
+    @Test(description = "Updating an Entity without passing the _Id as a parameter")
+    public void testUpdateInvalidEntity() {
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("entityType", "Automation_Entitytype");
+        requestBody.put("metaInformation.externalId", "");
+        requestBody.put("metaInformation.name", "");
+        requestBody.put("childHierarchyPath", new JSONArray());
+        requestBody.put("createdBy", "user123");
+        requestBody.put("updatedBy", "user123");
+        Response response = given()
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)
+                .header("x-auth-token", X_AUTH_TOKEN)
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .post("entity-management/v1/entities/update");
+        response.prettyPrint();
+        Assert.assertEquals(response.getStatusCode(), 400);
+        Assert.assertTrue(response.asString().contains("required _id"));
+        logger.info("Validation related to Invalid Updating of entity is verified");
+    }
+
+    @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
+    public void testFetchValidEntityDetails() {
+        Response response = fetchEntitydetails(randomExternalId);
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.jsonPath().getString("message").contains("ASSETS_FETCHED_SUCCESSFULLY"));
+        logger.info("Validations related to fetching the Valid single entity details is verified");
+    }
+
+    //This TC cannot be verified at the moment because there is an entity which is created with no name
+    @Test(description = "fetching entity details based on externalId", dependsOnMethods = "testAddingValidEntity")
+    public void testInvalidFetchEntityDetails() {
+        Response response = fetchEntitydetails("");
+        Assert.assertEquals(response.getStatusCode(), 400);
+        Assert.assertTrue(response.jsonPath().getString("message").contains("ENTITY_NOT_FOUND"));
+        logger.info("Validations related to fetching the Invalid single entity details is verified");
+    }
+
+    @Test(description = "Mapping the entities to parent entity using CSV upload")
+    public void testMappingEntities() {
+        addEntity(randomEntityName, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.Id"), randomExternalId, PropertyLoader.PROP_LIST.getProperty("elevate.qa.automation.entitytype.name"));
+        updateCSVWithChildAndParentEntityNames("src/main/resources/entities_mapping_ElevateProject.csv", "target/classes/entities_mapping_ElevateProject.csv", PropertyLoader.PROP_LIST.getProperty("elevate.qa.parent.entity.externalId"), randomExternalId);
+        Response response = uploadMappingCSV("target/classes/entities_mapping_ElevateProject.csv", PropertyLoader.PROP_LIST.getProperty("elevate.qa.mapping.entity.endpoint"));
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains("ENTITY_INFORMATION_UPDATE"));
+        logger.info("Validations related to Mapping entities are verified");
+    }
+
+    @Test(description = "Fetching the list of entities by using the entity Id", dependsOnMethods = "testMappingEntities")
+    public void fetchEntityListBasedOnEntityId() {
+        getSystemId(PropertyLoader.PROP_LIST.getProperty("elevate.qa.parent.entity.externalId"));
+        Response response = fetchEntityListBasedOnEntityId(entity_Id, "1", "100", "Automation_Entitytype");
+        Assert.assertEquals(response.getStatusCode(), 200);
+        Assert.assertTrue(response.asString().contains(randomEntityName), "Entity not found in the list");
+        logger.info("Entity count = " + response.jsonPath().getString("count"));
+        logger.info("Validations related to fetching entity list based on entity Id is verified");
     }
 
     // Method to add the entity
@@ -68,9 +148,9 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
     }
 
     // Method to update an entity by its ID
-    private Response updateEntity(String entityid ,String updatedEntityName, String updatedExternalId) {
+    private Response updateEntity(String entityid, String updatedEntityName, String updatedExternalId, String updatedEntityTypeName) {
         JSONObject requestBody = new JSONObject();
-
+        requestBody.put("entityType", updatedEntityTypeName);
         requestBody.put("metaInformation.externalId", updatedExternalId);
         requestBody.put("metaInformation.name", updatedEntityName);
         requestBody.put("childHierarchyPath", new JSONArray());
@@ -81,14 +161,72 @@ public class TestElevateEntityCRUDOperations extends ElevateProjectBaseTest {
                 .header("x-auth-token", X_AUTH_TOKEN)
                 .header("Content-Type", "application/json")
                 .body(requestBody)
-                .pathParam("_id",entityid )
+                .pathParam("_id", entityid)
                 .post(PropertyLoader.PROP_LIST.getProperty("elevate.qa.entityupdate.endpoint") + "{_id}");
         response.prettyPrint();
         return response;
     }
+
+    // Method to fetch Entity List based on entity Id
+    private Response fetchEntityListBasedOnEntityId(String entityid, String page, String limit, String entityType) {
+        Response response = given()
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)
+                .header("x-auth-token", X_AUTH_TOKEN)
+                .header("Content-Type", "application/json")
+                .pathParam("_id", entityid)
+                .queryParam("page", page)
+                .queryParam("limit", limit)
+                .queryParam("type", entityType)
+                .get(PropertyLoader.PROP_LIST.getProperty("elevate.qa.fetchentity.list.endpoint") + "{_id}");
+        response.prettyPrint();
+        return response;
+    }
+
+    // Method to fill the mapping CSV with child entity ID's
+    private void updateCSVWithChildAndParentEntityNames(String sourcePath, String targetPath, String parentEntityID, String ChildEntityId) {
+        try {
+            String CSVcontent = new String(Files.readAllBytes(Paths.get(sourcePath)));
+            logger.info("Original Content:\n" + CSVcontent);
+            List<String> parentEntityId;
+            parentEntityId = Collections.singletonList(getSystemId(parentEntityID));
+            for (String parentEntity_Id : parentEntityId) {
+                CSVcontent = CSVcontent.replaceFirst("parentEntity_Id", parentEntity_Id);
+                Files.write(Paths.get(targetPath), CSVcontent.getBytes());
+                logger.info("Updated Content:\n" + CSVcontent);
+            }
+
+            String CSVcontentChild = new String(Files.readAllBytes(Paths.get(targetPath)));
+            logger.info("Original Content:\n" + CSVcontentChild);
+            List<String> childEntityID;
+            childEntityID = Collections.singletonList(getSystemId(ChildEntityId));
+            for (String childEntity : childEntityID) {
+                CSVcontentChild = CSVcontentChild.replaceFirst("childEntity_ID", childEntity);
+                Files.write(Paths.get(targetPath), CSVcontentChild.getBytes());
+                logger.info("Updated Content:\n" + CSVcontentChild);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //Method to Map the child entity to parent entity using an CSV
+    private Response uploadMappingCSV(String targetPath, String endpoint) {
+        File csvFile = new File(targetPath);
+        if (!csvFile.exists()) {
+            logger.error("CSV file does not exist: " + csvFile.getAbsolutePath());
+        }
+        Response response = given()
+                .multiPart("entityMap", csvFile)
+                .header("internal-access-token", INTERNAL_ACCESS_TOKEN)  // Internal access token header
+                .header("x-auth-token", X_AUTH_TOKEN)  // x-authenticated-token header
+                .header("Content-Type", "multipart/form-data")
+                .post(endpoint);
+        logger.info("Response Status Code: " + response.getStatusCode());
+        response.prettyPrint();
+        return response;
+    }
 }
-
-
 
 
 


### PR DESCRIPTION
Adding CRUD Operations on Single entity
1. Added Tc's for
<include name="testUpdateEntityToDifferentEntityType"/>
<include name="testUpdateInvalidEntity"/>
<include name="testFetchValidEntityDetails"/>
<include name="testMappingEntities"/>
<include name="fetchEntityListBasedOnEntityId"/>

 2.  Added enhancement to the request body of
<include name="testUpdatingEntity"/>

3. Added methods for
a) fetchEntityListBasedOnEntityId
b) updateCSVWithChildAndParentEntityNames
c) uploadMappingCSV

And also enhanced the logger statements of the previous TC's for better readability and understanding.